### PR TITLE
POST /oauth/access_token API実装

### DIFF
--- a/lib/twimock/api/oauth.rb
+++ b/lib/twimock/api/oauth.rb
@@ -8,6 +8,12 @@ module Twimock
       def call(env)
         @app.call(env)
       end
+
+      private
+
+      def unauthorized
+        [ "401 Unauthorized", {}, "" ]
+      end
     end
   end
 end

--- a/lib/twimock/api/oauth_access_token.rb
+++ b/lib/twimock/api/oauth_access_token.rb
@@ -8,15 +8,67 @@ module Twimock
     class OAuthAccessToken < OAuth
       METHOD = "POST"
       PATH   = "/oauth/access_token"
+      AUTHORIZATION_REGEXP = /OAuth oauth_body_hash=\"(.*)\", oauth_consumer_key=\"(.*)\", oauth_nonce=\"(.*)\", oauth_signature=\"(.*)\", oauth_signature_method=\"(.*)\", oauth_timestamp=\"(.*)\", oauth_token=\"(.*)\", oauth_verifier=\"(.*)\", oauth_version=\"(.*)\"/
 
       def call(env)
         if env["REQUEST_METHOD"] == METHOD && env["PATH_INFO"] == PATH
-          # 認証
-          # Access Token発行
-          [ "201 Created", {}, [] ]
+          begin
+            auth_header = env["authorization"]
+            raise if auth_header.blank?
+            authorization = parse_authorization_header(auth_header.first)
+            raise unless validate_authorization_header(authorization)
+            raise unless application   = Twimock::Application.find_by_api_key(authorization.oauth_consumer_key)
+            raise unless request_token = Twimock::RequestToken.find_by_string(authorization.oauth_token)
+            raise unless request_token.application_id == application.id
+            raise unless user          = Twimock::User.find_by_id(request_token.user_id)
+          rescue
+            return unauthorized
+          end
+
+          status = "200 OK"
+          params = {
+            oauth_token:        user.access_token,
+            oauth_token_secret: user.access_token_secret,
+            user_id:            user.id,
+            screen_name:        user.twitter_id
+          }
+          body   = params.inject([]){|a, (k, v)| a << "#{k}=#{v}"}.join('&')
+          header = { "Content-Length" => body.bytesize }
+
+          [ status, header, [ body ] ]
         else
           super
         end
+      end
+
+      private
+
+      def parse_authorization_header(auth_header)
+        raise unless auth_header =~ AUTHORIZATION_REGEXP
+        authorization = Hashie::Mash.new
+        authorization.oauth_body_hash        = $1
+        authorization.oauth_consumer_key     = $2
+        authorization.oauth_nonce            = $3
+        authorization.oauth_signature        = $4
+        authorization.oauth_signature_method = $5
+        authorization.oauth_timestamp        = $6
+        authorization.oauth_token            = $7
+        authorization.oauth_verifier         = $8
+        authorization.oauth_version          = $9
+        authorization
+      end
+
+      def validate_authorization_header(authorization)
+        return false unless authorization.oauth_body_hash.size > 0
+        return false unless authorization.oauth_consumer_key.size > 0
+        return false unless authorization.oauth_nonce.size > 0
+        return false unless authorization.oauth_signature.size > 0
+        return false unless authorization.oauth_signature_method == "HMAC-SHA1"
+        return false unless authorization.oauth_timestamp.to_i > 0
+        return false unless authorization.oauth_token.size > 0
+        return false unless authorization.oauth_verifier.size > 0
+        return false unless authorization.oauth_version == "1.0"
+        true
       end
     end
   end

--- a/lib/twimock/api/oauth_request_token.rb
+++ b/lib/twimock/api/oauth_request_token.rb
@@ -38,10 +38,6 @@ module Twimock
 
       private
 
-      def unauthorized
-        [ "401 Unauthorized", {}, "" ]
-      end
-
       def validate_authorization_header(authorization)
         return false unless authorization.oauth_callback.size > 0
         return false unless authorization.oauth_consumer_key.size > 0

--- a/lib/twimock/database.rb
+++ b/lib/twimock/database.rb
@@ -95,12 +95,13 @@ module Twimock
         CREATE TABLE users (
           id                   INTEGER   PRIMARY KEY AUTOINCREMENT,
           name                 TEXT      NOT NULL,
+          twitter_id           TEXT      NOT NULL,
           password             TEXT      NOT NULL,
           access_token         TEXT      NOT NULL,
           access_token_secret  TEXT      NOT NULL,
           application_id       INTEGER   NOT NULL,
           created_at           DATETIME  NOT NULL,
-          UNIQUE(access_token, access_token_secret));
+          UNIQUE(twitter_id, access_token, access_token_secret));
       SQL
     end
 

--- a/lib/twimock/user.rb
+++ b/lib/twimock/user.rb
@@ -5,7 +5,7 @@ require 'twimock/request_token'
 module Twimock
   class User < Database::Table
     TABLE_NAME = :users
-    COLUMN_NAMES = [:id, :name, :password, :access_token, :access_token_secret, :application_id, :created_at]
+    COLUMN_NAMES = [:id, :name, :twitter_id, :password, :access_token, :access_token_secret, :application_id, :created_at]
     CHILDREN = [ RequestToken ]
 
     def initialize(options={})
@@ -13,6 +13,7 @@ module Twimock
       id = opts.id || opts.identifier
       @id                  = (id.to_i > 0) ? id.to_i : (Faker::Number.number(10)).to_i
       @name                = opts.name                || create_user_name
+      @twitter_id          = opts.twitter_id          || @name.downcase.gsub(" ", "_")
       @password            = opts.password            || Faker::Internet.password
       @access_token        = opts.access_token        || create_access_token
       @access_token_secret = opts.access_token_secret || Faker::Lorem.characters(45)
@@ -25,7 +26,7 @@ module Twimock
 
     def create_user_name
       n = Faker::Name.name
-      n.include?("'") ? create_user_name : n
+      (n.include?("'") || n.include?(".")) ? create_user_name : n
     end
 
     def create_access_token

--- a/spec/twimock/api/oauth_access_token_spec.rb
+++ b/spec/twimock/api/oauth_access_token_spec.rb
@@ -7,8 +7,26 @@ describe Twimock::API::OAuthAccessToken do
 
   let(:method) { 'POST' }
   let(:path)   { '/oauth/access_token' }
+  let(:authorization_regexp) { Regexp.new('OAuth oauth_body_hash=\"(.*)\", oauth_consumer_key=\"(.*)\", oauth_nonce=\"(.*)\", oauth_signature=\"(.*)\", oauth_signature_method=\"(.*)\", oauth_timestamp=\"(.*)\", oauth_token=\"(.*)\", oauth_verifier=\"(.*)\", oauth_version=\"(.*)\"') }
+  let(:body)     { "" }
+  let(:header)   { {} }
   let(:test_app) { TestApplicationHelper::TestRackApplication.new }
   let(:app)      { Twimock::API::OAuthAccessToken.new(test_app) }
+
+  def create_authorization_header(consumer_key, token)
+    params = {
+      body_hash:        "2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D",
+      consumer_key:     consumer_key,
+      nonce:            "IowIhqA1ckGHxbDL3pRVU3Td7BHfo2CWx7a6BArMveE",
+      signature:        "FfuyevfGWuVC5ZBUta0J4TmFFfQ%3D",
+      signature_method: "HMAC-SHA1",
+      timestamp:        "1422273884",
+      token:            token,
+      verifier:         "Mk8kPU3Del5IrhQuxdYAVVJIAHeetQ4M",
+      version:          "1.0" }
+    string = params.inject([]){|a, (k,v)| a << "oauth_#{k}=\"#{v}\"" }.join(", ")
+    [ "OAuth #{string}" ]
+  end
 
   describe '::METHOD' do
     subject { Twimock::API::OAuthAccessToken::METHOD }
@@ -20,13 +38,112 @@ describe Twimock::API::OAuthAccessToken do
     it { is_expected.to eq path }
   end
 
-  describe "POST '/oauth/access_token'" do
-    it 'should return 201 Created' do
-      post '/oauth/access_token'
+  describe '::AUTHORIZATION_REGEXP' do
+    subject { Twimock::API::OAuthAccessToken::AUTHORIZATION_REGEXP }
+    it { is_expected.to eq authorization_regexp }
+  end
 
-      expect(last_response.status).to eq 201
+  shared_context '401 Unauthorizaed OAuth Access Token', assert: :UnauthorizedOAuthAccessToken do
+    it 'should return 401 Unauthorized' do
+      post path, body, header
+
+      expect(last_response.status).to eq 401
+      expect(last_response.header).not_to be_blank
+      expect(last_response.header['Content-Length']).to eq 0.to_s
       expect(last_response.body).to be_blank
-      expect(last_response.header).to be_blank
+    end
+  end
+
+  describe "POST '/oauth/access_token'" do
+    context 'with authorization header' do
+      before { stub_const("Twimock::Database::DEFAULT_DB_NAME", db_name) }
+      after  { database.drop }
+
+      let(:db_name)  { ".test" }
+      let(:database) { Twimock::Database.new }
+
+      let(:header) { { "authorization" => @authorization } }
+
+      context 'that is correct' do
+        before do
+          app = Twimock::Application.new
+          app.save!
+          user = Twimock::User.new(application_id: app.id)
+          user.save!
+          request_token = Twimock::RequestToken.new(application_id: app.id, user_id: user.id)
+          request_token.save!
+
+          @authorization = create_authorization_header(app.api_key, request_token.string)
+        end
+
+        it 'should return 200 Created' do
+          post path, body, header
+
+          expect(last_response.status).to eq 200
+          expect(last_response.header).not_to be_blank
+          expect(last_response.header['Content-Length']).to eq last_response.body.bytesize.to_s
+          expect(last_response.body).not_to be_blank
+
+          index = last_response.body =~ /^oauth_token=(.*)&oauth_token_secret=(.*)&user_id=(.*)&screen_name=(.*)$/
+          expect(index).to eq 0
+          oauth_token        = $1
+          oauth_token_secret = $2
+          user_id            = $3.to_i
+          screen_name        = $4
+
+          user = Twimock::User.find_by_access_token(oauth_token)
+          expect(user).not_to be_nil
+          expect(oauth_token_secret).to eq user.access_token_secret
+          expect(user_id).to eq user.id
+          expect(screen_name).to eq user.twitter_id
+        end
+      end
+
+      context 'that is incorrect format', assert: :UnauthorizedOAuthAccessToken do
+        before { @authorization = ["OAuth consumer_key=\"test_consumer_key\, oauth_token=\"test_token\""] }
+      end
+
+      context 'but consumer_key is invalid', assert: :UnauthorizedOAuthAccessToken do
+        before do
+          app = Twimock::Application.new
+          request_token = Twimock::RequestToken.new(application_id: app.id)
+          @authorization = create_authorization_header(app.api_key, request_token.string)
+        end
+      end
+
+      context 'but oauth_token is invalid', assert: :UnauthorizedOAuthAccessToken do
+        before do
+          app = Twimock::Application.new
+          app.save!
+          request_token = Twimock::RequestToken.new(application_id: app.id)
+          @authorization = create_authorization_header(app.api_key, request_token.string)
+        end
+      end
+
+      context 'but oauth_token does not belong to user', assert: :UnauthorizedOAuthAccessToken do
+        before do
+          app = Twimock::Application.new
+          app.save!
+          request_token = Twimock::RequestToken.new(application_id: app.id)
+          request_token.save!
+          @authorization = create_authorization_header(app.api_key, request_token.string)
+        end
+      end
+
+      context 'but oauth_token does not belong to application', assert: :UnauthorizedOAuthAccessToken do
+        before do
+          app = Twimock::Application.new
+          app.save!
+          user = Twimock::User.new(application_id: app.id)
+          user.save!
+          request_token = Twimock::RequestToken.new(application_id: app.id)
+          request_token.save!
+          @authorization = create_authorization_header(app.api_key, request_token.string)
+        end
+      end
+    end
+
+    context 'without authorization header', assert: :UnauthorizedOAuthAccessToken do
     end
   end
 

--- a/spec/twimock/user_spec.rb
+++ b/spec/twimock/user_spec.rb
@@ -7,6 +7,7 @@ describe Twimock::User do
   let(:table_name)     { :users }
   let(:column_names)   { [ :id,
                            :name,
+                           :twitter_id,
                            :password,
                            :access_token,
                            :access_token_secret,
@@ -15,6 +16,7 @@ describe Twimock::User do
 
   let(:id)                  { 1 }
   let(:name)                { "test user" }
+  let(:twitter_id)          { "test_user" }
   let(:password)            { "testpass" }
   let(:access_token)        { "test_token" }
   let(:access_token_secret) { "test_token_secret" }
@@ -22,6 +24,7 @@ describe Twimock::User do
   let(:created_at)          { Time.now }
   let(:options)             { { id:                  id, 
                                 name:                name,
+                                twitter_id:          twitter_id,
                                 password:            password,
                                 access_token:        access_token,
                                 access_token_secret: access_token_secret,
@@ -58,6 +61,17 @@ describe Twimock::User do
         describe '.size' do
           subject { Twimock::User.new.name.size }
           it { is_expected.to be > 0 }
+        end
+      end
+
+      describe '.twitter_id' do
+        before { @user = Twimock::User.new }
+        subject { @user.twitter_id }
+        it { is_expected.to be_kind_of String }
+
+        describe '.size' do
+          subject { @user.twitter_id.size }
+          it { is_expected.to eq @user.name.size }
         end
       end
 


### PR DESCRIPTION
[POST oauth/request_token](https://dev.twitter.com/oauth/reference/post/oauth/access_token) のmock用ミドルウェア開発ブランチ。
#5 と同等の内容で作成。リファクタはここではしない。