### PR TITLE
Revert "ログインフォームのid, nameなどをhttps://www.twitter.comにあわせて修正"

### DIFF
--- a/view/authenticate.html.erb
+++ b/view/authenticate.html.erb
@@ -10,9 +10,9 @@
       <div class="auth">
         <h1>Twimockログイン</h1>
         <!-- POST https://twitter.com/intent/sessions -->
-        <form id="oauth_form" action="<%= @action_url %>" method="post">
-          <label>ユーザー名、またはメールアドレス<input type="text" id="username_or_email" name="session[username_or_email]"></label><br>
-          <label>パスワード<input type="password" id="password" name="session[password]"></label><br>
+        <form id="oauth_form" action="<%= @action_url %>" method="get">
+          <label>ユーザー名、またはメールアドレス<input type="text" name="username_or_email"></label><br>
+          <label>パスワード<input type="password" name="password"></label><br>
           <input type="hidden" name="remember_me" value="1">
           <input type="hidden" name="oauth_token" value="<%= @oauth_token %>">
           <input type="submit" value="ログイン" class="submit button selected" id="allow">


### PR DESCRIPTION
Reverts ogawatti/twimock#11

以下の理由でrevertかけます。
* Post /intent/sessions のパラメータがおかしいままテストを通過している
* 実際に使ってみるとパラメータがおかしいので、body["session[username_or_email"]でこける