### PR TITLE
authenticate_htmlとAPIの変更

### DIFF
--- a/lib/twimock/api/intent_sessions.rb
+++ b/lib/twimock/api/intent_sessions.rb
@@ -7,7 +7,7 @@ require 'twimock/errors'
 module Twimock
   module API
     # POST https://twitter.com/intent/sessions
-    #   body: { username_or_email: "xxx", password: "xxx", oauth_token: "xxx" }
+    #   body: { 'session[username_or_email]' => "xxx", 'session[password]' => "xxx", oauth_token: "xxx" }
     class IntentSessions < OAuth
       METHOD = "POST"
       PATH   = "/intent/sessions"
@@ -18,8 +18,8 @@ module Twimock
             request = Rack::Request.new(env)
             body = query_string_to_hash(request.body.read)
             @oauth_token       = body.oauth_token
-            @username_or_email = body.username_or_email
-            @password          = body.password
+            @username_or_email = body["session[username_or_email]"]
+            @password          = body["session[password]"]
 
             if !validate_oauth_token(@oauth_token)
               raise Twimock::Errors::InvalidRequestToken.new

--- a/spec/twimock/api/intent_sessions_spec.rb
+++ b/spec/twimock/api/intent_sessions_spec.rb
@@ -77,8 +77,8 @@ describe Twimock::API::IntentSessions do
     context 'with invalid oauth token', assert: :UnauthorizedRequestToken do
       before do
         request_token = Twimock::RequestToken.new
-        @body = { username_or_email: "testuser",
-                  password: "testpass",
+        @body = { 'session[username_or_email]' => "testuser",
+                  'session[password]' =>  "testpass",
                   oauth_token: request_token.string }
         post path, @body, header
       end
@@ -102,7 +102,7 @@ describe Twimock::API::IntentSessions do
         request_token.save!
         user          = Twimock::User.new(application_id: application.id, name: "testuser")
         user.save!
-        @body = { username_or_email: "invalidusername",
+        @body = { 'session[username_or_email]' => "invalidusername",
                   oauth_token: request_token.string }
       end
     end
@@ -115,8 +115,8 @@ describe Twimock::API::IntentSessions do
         request_token.save!
         user          = Twimock::User.new(application_id: application.id, password: "testpass")
         user.save!
-        @body = { username_or_email: user.twitter_id,
-                  password: "invalidpassword",
+        @body = { 'session[username_or_email]' => user.twitter_id,
+                  'session[password]' => "invalidpassword",
                   oauth_token: request_token.string }
       end
     end
@@ -129,8 +129,8 @@ describe Twimock::API::IntentSessions do
         @request_token.save!
         user          = Twimock::User.new(application_id: application.id)
         user.save!
-        @body = { username_or_email: user.twitter_id,
-                  password: user.password,
+        @body = { 'session[username_or_email]' => user.twitter_id,
+                  'session[password]' => user.password,
                   oauth_token: @request_token.string }
       end
     end
@@ -143,8 +143,8 @@ describe Twimock::API::IntentSessions do
         @request_token.save!
         user          = Twimock::User.new(application_id: application.id)
         user.save!
-        @body = { username_or_email: user.email,
-                  password: user.password,
+        @body = { 'session[username_or_email]' => user.email,
+                  'session[password]' => user.password,
                   oauth_token: @request_token.string }
       end
     end

--- a/view/authenticate.html.erb
+++ b/view/authenticate.html.erb
@@ -10,9 +10,9 @@
       <div class="auth">
         <h1>Twimockログイン</h1>
         <!-- POST https://twitter.com/intent/sessions -->
-        <form id="oauth_form" action="<%= @action_url %>" method="get">
-          <label>ユーザー名、またはメールアドレス<input type="text" name="username_or_email"></label><br>
-          <label>パスワード<input type="password" name="password"></label><br>
+        <form id="oauth_form" action="<%= @action_url %>" method="post">
+          <label>ユーザー名、またはメールアドレス<input type="text" id="username_or_email" name="session[username_or_email]"></label><br>
+          <label>パスワード<input type="password" id="password" name="session[password]"></label><br>
           <input type="hidden" name="remember_me" value="1">
           <input type="hidden" name="oauth_token" value="<%= @oauth_token %>">
           <input type="submit" value="ログイン" class="submit button selected" id="allow">


### PR DESCRIPTION
twimockのOAuthログイン用htmlのフォーム修正。
 * メソッドの変更 : Twimock::API::Intent::SessionsはPOST
 * id属性追加 / name属性の値を変更
 * APIの修正