### PR TITLE
env['HTTP_AUTHORIZATION']を追加

### DIFF
--- a/lib/twimock/api/account_verify_credentials.rb
+++ b/lib/twimock/api/account_verify_credentials.rb
@@ -13,7 +13,7 @@ module Twimock
       def call(env)
         if env["REQUEST_METHOD"] == METHOD && env["PATH_INFO"] == PATH
           begin
-            auth_header = env["authorization"]
+            auth_header = env["authorization"] || env["HTTP_AUTHORIZATION"]
             raise if auth_header.blank?
             authorization = parse_authorization_header(auth_header.first)
             raise unless validate_authorization_header(authorization)

--- a/lib/twimock/api/oauth_access_token.rb
+++ b/lib/twimock/api/oauth_access_token.rb
@@ -13,7 +13,7 @@ module Twimock
       def call(env)
         if env["REQUEST_METHOD"] == METHOD && env["PATH_INFO"] == PATH
           begin
-            auth_header = env["authorization"]
+            auth_header = env["authorization"] || env["HTTP_AUTHORIZATION"]
             raise if auth_header.blank?
             authorization = case auth_header
             when Array  then parse_authorization_header(auth_header.first)


### PR DESCRIPTION
Twimock::OauthAccessToken内でAuthorizationヘッダを取得できていなかった。
lib/twimock/api/oauth_request_token.rbには
```auth_header = env["authorization"] || env["HTTP_AUTHORIZATION"]```が実装済みだったが、
Twimock::AccountVerifyCredentials, Twimock::OAuthAccessTokenは抜けていたため、追加。
共通化できるので、要リファクタ(今回はしない)