### PR TITLE
Twimock::IntentSessions.query_string_to_hashでエラーが発生する

### DIFF
--- a/lib/twimock/api/intent_sessions.rb
+++ b/lib/twimock/api/intent_sessions.rb
@@ -67,6 +67,8 @@ module Twimock
       end
 
       def query_string_to_hash(query_string)
+        # 結合すると以下のエラーが出る
+        # NameError: uninitialized constant URI::WFKV_
         ary  = URI::decode_www_form(query_string)
         hash = Hash[ary]
         Hashie::Mash.new(hash)


### PR DESCRIPTION
結合すると、以下のエラーが出ます。
NameError: uninitialized constant URI::WFKV_
