### PR TITLE
:airplane: URI::decode_www_form削除

### DIFF
--- a/lib/twimock/api/intent/sessions.rb
+++ b/lib/twimock/api/intent/sessions.rb
@@ -48,7 +48,7 @@ module Twimock
             response
           rescue Twimock::Errors::InvalidRequestToken => @error
             return unauthorized
-          rescue
+          rescue => @error
             internal_server_error
           end
         end

--- a/lib/twimock/api/oauth.rb
+++ b/lib/twimock/api/oauth.rb
@@ -67,9 +67,8 @@ module Twimock
       end
 
       def query_string_to_hash(query_string)
-        ary  = URI::decode_www_form(query_string)
-        hash = Hash[ary]
-        Hashie::Mash.new(hash)
+        ary = URI.decode(query_string).split("&").inject([]){|a, s| a << s.split("=")}
+        Hashie::Mash.new(Hash[ary])
       end
 
       def generate_error_response(status)


### PR DESCRIPTION
某実装で該当のメソッドがオーバーライドされている。
影響範囲が読めないので、こちらで使わないようにして対応する。