### PR TITLE
Twimock::Config.load_usersのバグ修正

### DIFF
--- a/lib/twimock/config.rb
+++ b/lib/twimock/config.rb
@@ -50,10 +50,12 @@ module Twimock
         end
 
         # Create application and user record
-        app = Twimock::Application.create!({ id: app_id, api_key: api_key, api_secret: api_secret })
+        unless app = Twimock::Application.find_by_api_key(api_key)
+          app = Twimock::Application.create!({ id: app_id, api_key: api_key, api_secret: api_secret })
+        end
         users.each do |options|
           user = Twimock::User.new(options)
-          unless Twimock::User.find_by_id(user.id)
+          unless Twimock::User.find_by_name(user.name)
             user.application_id = app.id
             user.save!
           end

--- a/spec/twimock/config_spec.rb
+++ b/spec/twimock/config_spec.rb
@@ -160,7 +160,7 @@ def app_data(user_count = 1)
   users = []
   user_count.times do
     user = { id: Faker::Number.number(15),
-             name: 'test_user',
+             name: Faker::Name.first_name,
              password: 'test_pass',
              access_token: 'test_token',
              access_token_secret: "test_token_secret_#{Faker::Number.number(15)}",
@@ -168,7 +168,7 @@ def app_data(user_count = 1)
     users.push user
   end
   app = { id: app_id,
-          api_key: 'test_api_key',
+          api_key: "test_api_key_#{app_id}",
           api_secret: "test_api_secret_#{app_id}",
           users: users }
 end


### PR DESCRIPTION
(※ validateの緩和は別プルリクで対応する)

Twimock::Config.load_usersでYAMLファイルからアプリ/ユーザ登録をしようとした。
しかし、アプリ作成時に```Twimock::Application.find_by_api_key(api_key)```を確認していなかった。
そのため、テストの前提でそのスクリプトを通過すると、同じapi_keyで新たにアプリを登録しようとして失敗していた(api_key is not unique)

ユーザ作成では作成前にユーザの有無を確認していたが、find_by_nameで検証していなかったためユーザのidを固定かつ指定していないとスクリプトを叩くごとにユーザが増加してしまうことが発覚。
(Twitterのnameは一意なので検証ではnameを使用)