### PR TITLE
AccessTokenとアプリとの紐付けを追加

### DIFF
--- a/lib/twimock/config.rb
+++ b/lib/twimock/config.rb
@@ -57,6 +57,7 @@ module Twimock
           user.save! unless Twimock::User.find_by_id(user.id)
           unless Twimock::AccessToken.find_by_string(access_token.string)
             access_token.user_id = user.id
+            access_token.application_id = app_id
             access_token.save!
           end
         end

--- a/spec/twimock/config_spec.rb
+++ b/spec/twimock/config_spec.rb
@@ -117,10 +117,8 @@ describe Twimock::Config do
 
         [:id, :name, :password].each do |key|
           context "when users #{key} is not exist" do
-            before do
-              app[:users].first.delete(key)
-              it_behaves_like 'IncorrectDataFormat'
-            end
+            before { app[:users].first.delete(key) }
+            it_behaves_like 'IncorrectDataFormat'
           end
         end
       end
@@ -150,6 +148,7 @@ describe Twimock::Config do
           access_token  = access_tokens.first
           expect(access_token.string).to eq user[:access_token]
           expect(access_token.secret).to eq user[:access_token_secret]
+          expect(access_token.application_id).to eq app[:id]
         end
       end
 


### PR DESCRIPTION
#### 前提
* Twimock::Config.load_usersでアプリ/ユーザを登録している

#### 現象
* 前提で登録したユーザーのOAuthログインに失敗する
 * ログイン時の下記validationでfalseになっていた(L37)

```
# lib/twimock/api/oauth.rb
 34       def validate_access_token(access_token_string, application_id)
 35         return false if access_token_string.blank?
 36         return false unless access_token = Twimock::AccessToken.find_by_string(access_token_string)
 37         return false unless access_token.application_id # <= nil
 38         return false unless access_token.application_id == application_id
 39         true
 40       end
```

#### 原因
* https://github.com/ogawatti/twimock/pull/19 でAccessTokenとアプリとの紐付けが漏れている
 * https://github.com/ogawatti/twimock/blob/develop/lib/twimock/config.rb#L59-L60

```lib/twimock/config.rb
 50         # Create application and user record
 ...
 58           unless Twimock::AccessToken.find_by_string(access_token.string)
 59             access_token.user_id = user.id
 60             access_token.save!
 61           end
```

#### やること、やったこと
* 上記バグの修正
* 既存のテストのリファクタ
