### PR TITLE
ログイン画面の日本語表記を英語に変更

### DIFF
--- a/view/authenticate.html.erb
+++ b/view/authenticate.html.erb
@@ -2,20 +2,20 @@
 <html lang="ja" dir="ltr" class="">
   <head>
     <meta charset="utf-8">
-    <title>Twimock / アプリケーション認証</title>
+    <title>Authorize Twimock Application</title>
   </head>
 
   <body class="oauth authenticate write tfw ja logged-out noloki">
     <div id="bd" role="main">
       <div class="auth">
-        <h1>Twimockログイン</h1>
+        <h1>Login Twimock</h1>
         <!-- POST https://twitter.com/intent/sessions -->
         <form id="oauth_form" action="<%= @action_url %>" method="post">
-          <label>ユーザー名、またはメールアドレス<input type="text" id="username_or_email" name="session[username_or_email]"></label><br>
-          <label>パスワード<input type="password" id="password" name="session[password]"></label><br>
+          <label>Username or email<input type="text" id="username_or_email" name="session[username_or_email]"></label><br>
+          <label>Password<input type="password" id="password" name="session[password]"></label><br>
           <input type="hidden" name="remember_me" value="1">
           <input type="hidden" name="oauth_token" value="<%= @oauth_token %>">
-          <input type="submit" value="ログイン" class="submit button selected" id="allow">
+          <input type="submit" value="login" class="submit button selected" id="allow">
         </form>
       </div>
     </div>


### PR DESCRIPTION
#### 背景
* 日本語のフォントが入っていない環境など、Twimockログインのフォームの文字が化けてしまう

####  やること
* 今ある日本語表記を英語に変更する